### PR TITLE
Feature/paginated resources

### DIFF
--- a/src/Controllers/ResourceController.php
+++ b/src/Controllers/ResourceController.php
@@ -46,7 +46,7 @@ class ResourceController extends Controller
 
         $models = $this->indexModel();
 
-        $resources = resource($models, true);
+        $resources = resource($models);
 
         return ok($resources);
     }

--- a/src/Controllers/ResourceController.php
+++ b/src/Controllers/ResourceController.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Foundation\Bus\DispatchesJobs;
-use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use OwowAgency\LaravelResources\Requests\ResourceRequest;
@@ -49,11 +48,7 @@ class ResourceController extends Controller
 
         $resources = resource($models, true);
 
-        if ($models instanceof LengthAwarePaginator) {
-            $models->setCollection($resources->collection);
-        }
-
-        return ok($models);
+        return ok($resources);
     }
 
     /**

--- a/src/Library/helpers.php
+++ b/src/Library/helpers.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Support\Collection;
-use Illuminate\Pagination\LengthAwarePaginator;
 use OwowAgency\LaravelResources\Resources\ResourceFactory;
 
 if (! function_exists('resource')) {
@@ -9,30 +7,11 @@ if (! function_exists('resource')) {
      * Makes the resource for the specified model class.
      *
      * @param  mixed  $model
-     * @param  boolean  $isCollection|null
+     * @param  boolean  $isPlural
      * @return mixed
      */
-    function resource($model, $isCollection = null)
+    function resource($model, $isPlural = null)
     {
-        if (is_null($isCollection)) {
-            if (
-                $model instanceof Collection
-                || $model instanceof LengthAwarePaginator
-            ) {
-                $isCollection = true;
-            } else {
-                $isCollection = false;
-            }
-        }
-
-        $resource = (new ResourceFactory)->make($model, $isCollection);
-
-        if ($model instanceof LengthAwarePaginator) {
-            $model->setCollection($resource->collection);
-
-            return $model;
-        }
-
-        return $resource;
+        return (new ResourceFactory)->make($model, $isPlural);
     }
 }

--- a/src/Library/helpers.php
+++ b/src/Library/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Pagination\LengthAwarePaginator;
 use OwowAgency\LaravelResources\Resources\ResourceFactory;
 
 if (! function_exists('resource')) {
@@ -12,6 +13,14 @@ if (! function_exists('resource')) {
      */
     function resource($model, $isCollection = false)
     {
-        return (new ResourceFactory)->make($model, $isCollection);
+        $resource = (new ResourceFactory)->make($model, $isCollection);
+
+        if ($model instanceof LengthAwarePaginator) {
+            $model->setCollection($resource->collection);
+
+            return $model;
+        }
+
+        return $resource;
     }
 }

--- a/src/Library/helpers.php
+++ b/src/Library/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
 use OwowAgency\LaravelResources\Resources\ResourceFactory;
 
@@ -8,11 +9,22 @@ if (! function_exists('resource')) {
      * Makes the resource for the specified model class.
      *
      * @param  mixed  $model
-     * @param  boolean  $isCollection
+     * @param  boolean  $isCollection|null
      * @return mixed
      */
-    function resource($model, $isCollection = false)
+    function resource($model, $isCollection = null)
     {
+        if (is_null($isCollection)) {
+            if (
+                $model instanceof Collection
+                || $model instanceof LengthAwarePaginator
+            ) {
+                $isCollection = true;
+            } else {
+                $isCollection = false;
+            }
+        }
+
         $resource = (new ResourceFactory)->make($model, $isCollection);
 
         if ($model instanceof LengthAwarePaginator) {

--- a/src/Resources/ResourceFactory.php
+++ b/src/Resources/ResourceFactory.php
@@ -39,9 +39,9 @@ class ResourceFactory
      *
      * @param  mixed  $model
      * @param  boolean  $isPlural
-     * @return Illuminate\Http\Resources\Json\JsonResource|
-     *         Illuminate\Http\Resources\Json\AnonymousResourceCollection|
-     *         Illuminate\Pagination\LengthAwarePaginator
+     * @return Illuminate\Http\Resources\Json\JsonResource
+     *         | Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     *         | Illuminate\Pagination\LengthAwarePaginator
      *
      * @throws \Exception
      */


### PR DESCRIPTION
Modify `resource()` helper function, so that:
- It can detect if `$model` is collection or not, thus `$isCollection` is not required anymore. (Fix #18)
- It can detect and return paginated models, thus user don't have to meddle with `$model->setCollection($resource->collection);` anymore.

**It is a breaking change to the `resource()` function.**